### PR TITLE
Switch to CredentialsProvider and SMTP email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# URL of your authentication API
+AUTH_API_URL=http://localhost:3000/api
+
+# SMTP configuration for sending emails
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=user@example.com
+SMTP_PASS=password
+# Set to true if using TLS/SSL
+SMTP_SECURE=false
+# Optional from address
+SMTP_FROM="eCF MSeller <no-reply@example.com>"

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Configuration
+
+Create a `.env` file based on `.env.example` and provide your SMTP settings along with the URL of your authentication API.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "postinstall": "npm run build:icons"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.721.0",
     "@emotion/cache": "11.13.0",
     "@emotion/react": "11.13.0",
     "@emotion/styled": "11.13.0",
@@ -44,7 +43,8 @@
     "react-toastify": "^11.0.2",
     "react-use": "17.5.1",
     "server-only": "0.0.1",
-    "yup": "^1.6.1"
+    "yup": "^1.6.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@iconify/json": "^2.2.292",

--- a/src/libs/email.ts
+++ b/src/libs/email.ts
@@ -1,0 +1,25 @@
+import nodemailer from 'nodemailer'
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT) || 587,
+  secure: process.env.SMTP_SECURE === 'true',
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS
+  }
+})
+
+export interface MailOptions {
+  to: string
+  subject: string
+  text?: string
+  html?: string
+}
+
+export async function sendMail(options: MailOptions) {
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    ...options
+  })
+}

--- a/src/libs/token-store.ts
+++ b/src/libs/token-store.ts
@@ -1,0 +1,26 @@
+const passwordResetTokens = new Map<string, string>()
+const verificationTokens = new Map<string, string>()
+
+export function setPasswordResetToken(email: string, token: string) {
+  passwordResetTokens.set(email, token)
+}
+
+export function getPasswordResetToken(email: string) {
+  return passwordResetTokens.get(email)
+}
+
+export function removePasswordResetToken(email: string) {
+  passwordResetTokens.delete(email)
+}
+
+export function setVerificationToken(email: string, token: string) {
+  verificationTokens.set(email, token)
+}
+
+export function getVerificationToken(email: string) {
+  return verificationTokens.get(email)
+}
+
+export function removeVerificationToken(email: string) {
+  verificationTokens.delete(email)
+}

--- a/src/utils/calculateSecretHash.ts
+++ b/src/utils/calculateSecretHash.ts
@@ -1,9 +1,0 @@
-import * as crypto from 'crypto'
-
-export const calculateSecretHash = (username: string): string => {
-  const message = username + process.env.COGNITO_CLIENT_ID
-
-  const hash = crypto.createHmac('SHA256', process.env.COGNITO_CLIENT_SECRET!).update(message).digest('base64')
-
-  return hash
-}


### PR DESCRIPTION
## Summary
- simplify auth provider to NextAuth CredentialsProvider
- add nodemailer-based email helper
- add in-memory token store and SMTP-driven auth routes
- document new environment variables

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843ab24ec108329814a436b38aafcc1